### PR TITLE
Add auth and subscription gating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Local Supabase config
+supabase-config.js

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # FleetForge
 FleetForge – a lightweight, modular Trucking Management System (TMS) built for dispatchers and fleet owners.
+
+## Authentication Setup
+
+Copy `supabase-config.example.js` to `supabase-config.js` and add your Supabase project URL and anon key. These values are required for login and database access.
+
+```
+cp supabase-config.example.js supabase-config.js
+# edit supabase-config.js with your credentials
+```

--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,18 @@
+function requireAuth() {
+  return supabase.auth.getUser().then(({ data }) => {
+    if (!data || !data.user) {
+      window.location.href = 'login.html';
+      return Promise.reject();
+    }
+    return data.user;
+  });
+}
+
+function requirePaid() {
+  const paid = localStorage.getItem('paid');
+  if (!paid) {
+    window.location.href = 'pricing.html';
+    return false;
+  }
+  return true;
+}

--- a/dispatch-form.html
+++ b/dispatch-form.html
@@ -5,12 +5,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Dispatch Form - FleetForge</title>
   <link rel="stylesheet" href="styles.css" />
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@1"></script>
+  <script src="supabase-config.js"></script>
+  <script src="auth.js"></script>
 </head>
 <body>
   <nav>
     <a href="index.html">Home</a>
     <a href="dispatch-form.html">Dispatch Form</a>
     <a href="dispatch-log.html">Dispatch Log</a>
+    <a href="#" id="logout">Logout</a>
   </nav>
   <header>
     <h1>Dispatch Form</h1>
@@ -33,21 +37,30 @@
     </form>
   </main>
   <script>
-    const form = document.getElementById('dispatchForm');
-    form.addEventListener('submit', function(e) {
-      e.preventDefault();
-      const dispatches = JSON.parse(localStorage.getItem('dispatches') || '[]');
-      const entry = {
-        loadNumber: document.getElementById('loadNumber').value,
-        driverName: document.getElementById('driverName').value,
-        origin: document.getElementById('origin').value,
-        destination: document.getElementById('destination').value,
-        date: new Date().toISOString()
-      };
-      dispatches.push(entry);
-      localStorage.setItem('dispatches', JSON.stringify(dispatches));
-      form.reset();
-      window.location.href = 'dispatch-log.html';
+    requireAuth().then(() => {
+      if (!requirePaid()) return;
+      document.getElementById('logout').addEventListener('click', async (e) => {
+        e.preventDefault();
+        await supabase.auth.signOut();
+        localStorage.removeItem('paid');
+        window.location.href = 'index.html';
+      });
+      const form = document.getElementById('dispatchForm');
+      form.addEventListener('submit', async function(e) {
+        e.preventDefault();
+        const { data: { user } } = await supabase.auth.getUser();
+        const entry = {
+          load_number: document.getElementById('loadNumber').value,
+          driver_name: document.getElementById('driverName').value,
+          origin: document.getElementById('origin').value,
+          destination: document.getElementById('destination').value,
+          date: new Date().toISOString(),
+          user_id: user.id
+        };
+        await supabase.from('dispatches').insert(entry);
+        form.reset();
+        window.location.href = 'dispatch-log.html';
+      });
     });
   </script>
 </body>

--- a/dispatch-log.html
+++ b/dispatch-log.html
@@ -5,12 +5,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Dispatch Log - FleetForge</title>
   <link rel="stylesheet" href="styles.css" />
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@1"></script>
+  <script src="supabase-config.js"></script>
+  <script src="auth.js"></script>
 </head>
 <body>
   <nav>
     <a href="index.html">Home</a>
     <a href="dispatch-form.html">Dispatch Form</a>
     <a href="dispatch-log.html">Dispatch Log</a>
+    <a href="#" id="logout">Logout</a>
   </nav>
   <header>
     <h1>Dispatch Log</h1>
@@ -31,23 +35,33 @@
     </table>
   </main>
   <script>
-    function renderLog() {
+    requireAuth().then(async user => {
+      if (!requirePaid()) return;
+      document.getElementById('logout').addEventListener('click', async (e) => {
+        e.preventDefault();
+        await supabase.auth.signOut();
+        localStorage.removeItem('paid');
+        window.location.href = 'index.html';
+      });
       const tbody = document.querySelector('#logTable tbody');
       tbody.innerHTML = '';
-      const dispatches = JSON.parse(localStorage.getItem('dispatches') || '[]');
-      dispatches.forEach(d => {
+      const { data } = await supabase
+        .from('dispatches')
+        .select('*')
+        .eq('user_id', user.id)
+        .order('date', { ascending: false });
+      (data || []).forEach(d => {
         const row = document.createElement('tr');
         row.innerHTML = `
-          <td>${d.loadNumber}</td>
-          <td>${d.driverName}</td>
+          <td>${d.load_number}</td>
+          <td>${d.driver_name}</td>
           <td>${d.origin}</td>
           <td>${d.destination}</td>
           <td>${new Date(d.date).toLocaleString()}</td>
         `;
         tbody.appendChild(row);
       });
-    }
-    renderLog();
+    });
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -5,12 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>FleetForge – by JSBS</title>
   <link rel="stylesheet" href="styles.css" />
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@1"></script>
+  <script src="supabase-config.js"></script>
 </head>
 <body>
   <nav>
     <a href="index.html">Home</a>
     <a href="dispatch-form.html">Dispatch Form</a>
     <a href="dispatch-log.html">Dispatch Log</a>
+    <a href="login.html" id="loginLink">Login</a>
   </nav>
   <header>
     <img src="jsbs-logo.jpg" alt="JSBS Logo" class="logo" />
@@ -18,5 +21,19 @@
     <p>Built by Jagne Small Business Services – Powering Dispatch & Fleet Growth</p>
     <a href="dispatch-form.html" class="btn">Get Started</a>
   </header>
+  <script>
+    const link = document.getElementById('loginLink');
+    supabase.auth.getUser().then(({ data }) => {
+      if (data && data.user) {
+        link.textContent = 'Logout';
+        link.addEventListener('click', async (e) => {
+          e.preventDefault();
+          await supabase.auth.signOut();
+          localStorage.removeItem('paid');
+          window.location.reload();
+        });
+      }
+    });
+  </script>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Login - FleetForge</title>
+  <link rel="stylesheet" href="styles.css" />
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@1"></script>
+  <script src="supabase-config.js"></script>
+  <script src="auth.js"></script>
+</head>
+<body>
+  <main>
+    <h1>Login</h1>
+    <form id="loginForm">
+      <label>Email
+        <input type="email" id="email" required />
+      </label>
+      <label>Password
+        <input type="password" id="password" required />
+      </label>
+      <button type="submit" class="btn">Login</button>
+    </form>
+    <p>Don't have an account? <a href="signup.html">Sign up</a></p>
+    <p id="error" class="error"></p>
+  </main>
+  <script>
+    supabase.auth.getUser().then(({ data }) => {
+      if (data && data.user) {
+        window.location.href = 'dispatch-form.html';
+      }
+    });
+    const form = document.getElementById('loginForm');
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const { error } = await supabase.auth.signIn({
+        email: document.getElementById('email').value,
+        password: document.getElementById('password').value
+      });
+      if (error) {
+        document.getElementById('error').textContent = error.message;
+      } else {
+        window.location.href = 'dispatch-form.html';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/pricing.html
+++ b/pricing.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pricing - FleetForge</title>
+  <link rel="stylesheet" href="styles.css" />
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@1"></script>
+  <script src="supabase-config.js"></script>
+  <script src="auth.js"></script>
+</head>
+<body>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="#" id="logout">Logout</a>
+  </nav>
+  <main>
+    <h1>Subscribe to FleetForge</h1>
+    <p>$9.99/month gives you full access to the dispatch dashboard.</p>
+    <button id="subscribeBtn" class="btn">Subscribe with Stripe</button>
+  </main>
+  <script>
+    requireAuth().then(() => {
+      document.getElementById('logout').addEventListener('click', async (e) => {
+        e.preventDefault();
+        await supabase.auth.signOut();
+        localStorage.removeItem('paid');
+        window.location.href = 'index.html';
+      });
+    });
+    document.getElementById('subscribeBtn').addEventListener('click', () => {
+      // Replace URL with your Stripe payment link
+      const stripeUrl = 'https://buy.stripe.com/test_placeholder';
+      const successUrl = window.location.origin + '/dispatch-form.html';
+      localStorage.setItem('paid', 'true');
+      window.location.href = stripeUrl + '?redirect=' + encodeURIComponent(successUrl);
+    });
+  </script>
+</body>
+</html>

--- a/signup.html
+++ b/signup.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sign Up - FleetForge</title>
+  <link rel="stylesheet" href="styles.css" />
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@1"></script>
+  <script src="supabase-config.js"></script>
+  <script src="auth.js"></script>
+</head>
+<body>
+  <main>
+    <h1>Sign Up</h1>
+    <form id="signupForm">
+      <label>Email
+        <input type="email" id="email" required />
+      </label>
+      <label>Password
+        <input type="password" id="password" required />
+      </label>
+      <button type="submit" class="btn">Create Account</button>
+    </form>
+    <p>Already have an account? <a href="login.html">Login</a></p>
+    <p id="error" class="error"></p>
+  </main>
+  <script>
+    supabase.auth.getUser().then(({ data }) => {
+      if (data && data.user) {
+        window.location.href = 'dispatch-form.html';
+      }
+    });
+    const form = document.getElementById('signupForm');
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const { error } = await supabase.auth.signUp({
+        email: document.getElementById('email').value,
+        password: document.getElementById('password').value
+      });
+      if (error) {
+        document.getElementById('error').textContent = error.message;
+      } else {
+        window.location.href = 'pricing.html';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -94,4 +94,19 @@ th {
   background-color: #333;
 }
 
+.error {
+  color: #ff6b6b;
+  margin-top: 1rem;
+}
+
+@media (max-width: 600px) {
+  nav a {
+    display: block;
+    margin: 0.5rem 0;
+  }
+  .btn {
+    width: 100%;
+  }
+}
+
 

--- a/supabase-config.example.js
+++ b/supabase-config.example.js
@@ -1,0 +1,4 @@
+// Replace with your Supabase project credentials
+const SUPABASE_URL = 'https://your-project.supabase.co';
+const SUPABASE_ANON_KEY = 'your-anon-key';
+const supabase = supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);


### PR DESCRIPTION
## Summary
- add Supabase auth setup example and login/signup/pricing pages
- gate dispatch pages behind login and subscription check
- store per-user dispatches in Supabase
- update styles for error messages and mobile nav

## Testing
- `npm install @supabase/supabase-js` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_687826d7e2b0832cae34529fd74f3632