### PR TITLE
Secure subscription check

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Create a `loads` table in Supabase with the following columns:
 - `status` (text)
 - `created_at` (timestamp)
 
+Create a `subscriptions` table with:
+
+- `user_id` (uuid, primary key references auth.users)
+- `active` (boolean)
+
 ## Authentication Setup
 
 Copy `supabase-config.example.js` to `supabase-config.js` and add your Supabase project URL and anon key. These values are required for login and database access.

--- a/dispatch-form.html
+++ b/dispatch-form.html
@@ -40,8 +40,8 @@
     </form>
   </main>
   <script>
-    requireAuth().then(() => {
-      if (!requirePaid()) return;
+    requireAuth().then(async () => {
+      if (!await requirePaid()) return;
       document.getElementById('logout').addEventListener('click', async (e) => {
         e.preventDefault();
         await supabase.auth.signOut();

--- a/dispatch-log.html
+++ b/dispatch-log.html
@@ -38,7 +38,7 @@
   </main>
   <script>
     requireAuth().then(async user => {
-      if (!requirePaid()) return;
+      if (!await requirePaid()) return;
       document.getElementById('logout').addEventListener('click', async (e) => {
         e.preventDefault();
         await supabase.auth.signOut();


### PR DESCRIPTION
## Summary
- store subscription data in a `subscriptions` table
- verify user subscription status with Supabase in `requirePaid()`
- await `requirePaid()` when gating dispatch pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687acb1c05d0832ca1c7842297e09d4e