### PR TITLE
Improve README setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,40 @@ Copy `supabase-config.example.js` to `supabase-config.js` and add your Supabase 
 cp supabase-config.example.js supabase-config.js
 # edit supabase-config.js with your credentials
 ```
+
+## Row Level Security
+
+Enable RLS on your tables so each user only sees their own data. Example SQL:
+
+```sql
+-- Loads table policies
+alter table loads enable row level security;
+create policy "Loads owned by user" on loads
+  for select using (auth.uid() = user_id);
+create policy "Insert own loads" on loads
+  for insert with check (auth.uid() = user_id);
+
+-- Subscriptions table policies
+alter table subscriptions enable row level security;
+create policy "Read own subscription" on subscriptions
+  for select using (auth.uid() = user_id);
+```
+
+## Serving the App
+
+You can deploy the static site with any static host (e.g. Netlify). To test
+locally, run:
+
+```
+npx serve -s .
+```
+
+Then visit the printed URL (usually `http://localhost:3000`).
+
+## Testing
+
+1. Copy and configure `supabase-config.js`.
+2. Create the tables and policies as shown above.
+3. Start the static server and sign up for an account.
+4. Add a load via `dispatch-form.html` and verify it appears in the log for that
+   user only.


### PR DESCRIPTION
## Summary
- document how to copy `supabase-config.example.js` and fill in credentials
- outline row level security policies for the example tables
- show how to serve the static site with `npx serve`
- add manual testing steps

## Testing
- `npx serve --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687bb80c3784832c9debd329d4bdc471