### PR TITLE
Implement dashboard page and auth redirects

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,11 +1,20 @@
 function requireAuth() {
   return supabase.auth.getUser().then(({ data }) => {
+    const path = window.location.pathname;
+    const isAuthPage = /(login|signup)(\.html)?$/.test(path);
+
     if (!data || !data.user) {
       const sess = localStorage.getItem('sb-session');
       if (sess) {
         return supabase.auth.setSession(JSON.parse(sess).session).then(() => {
           return supabase.auth.getUser().then(({ data }) => {
-            if (data && data.user) return data.user;
+            if (data && data.user) {
+              if (isAuthPage) {
+                window.location.href = 'dashboard.html';
+                return Promise.reject();
+              }
+              return data.user;
+            }
             window.location.href = 'login.html';
             return Promise.reject();
           });
@@ -14,6 +23,12 @@ function requireAuth() {
       window.location.href = 'login.html';
       return Promise.reject();
     }
+
+    if (isAuthPage) {
+      window.location.href = 'dashboard.html';
+      return Promise.reject();
+    }
+
     return data.user;
   });
 }

--- a/dashboard.html
+++ b/dashboard.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Dispatch Form - FleetForge</title>
+  <title>Dashboard - FleetForge</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" />
   <link rel="stylesheet" href="styles.css" />
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@1"></script>
@@ -13,12 +13,12 @@
 <body class="bg-gray-100 text-gray-800">
   <nav class="bg-white shadow p-4 flex gap-4 justify-center">
     <a href="index.html" class="font-semibold">Home</a>
-    <a href="dispatch-form.html">Dispatch Form</a>
+    <a href="dashboard.html">Dashboard</a>
     <a href="dispatch-log.html">Dispatch Log</a>
     <a href="#" id="logout">Logout</a>
   </nav>
   <header class="text-center py-6">
-    <h1 class="text-2xl font-bold">Dispatch Form</h1>
+    <h1 class="text-2xl font-bold">Dashboard</h1>
   </header>
   <main class="max-w-xl mx-auto p-4">
     <form id="dispatchForm" class="space-y-4">

--- a/dispatch-log.html
+++ b/dispatch-log.html
@@ -13,7 +13,7 @@
 <body class="bg-gray-100 text-gray-800">
   <nav class="bg-white shadow p-4 flex gap-4 justify-center">
     <a href="index.html" class="font-semibold">Home</a>
-    <a href="dispatch-form.html">Dispatch Form</a>
+    <a href="dashboard.html">Dashboard</a>
     <a href="dispatch-log.html">Dispatch Log</a>
     <a href="#" id="logout">Logout</a>
   </nav>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 <body class="bg-gray-100 text-gray-800">
   <nav class="bg-white shadow p-4 flex gap-4 justify-center">
     <a href="index.html" class="font-semibold">Home</a>
-    <a href="dispatch-form.html">Dispatch Form</a>
+    <a href="dashboard.html">Dashboard</a>
     <a href="dispatch-log.html">Dispatch Log</a>
     <a href="login.html" id="loginLink">Login</a>
   </nav>
@@ -20,7 +20,7 @@
     <img src="jsbs-logo.jpg" alt="JSBS Logo" class="mx-auto mb-4 logo" />
     <h1 class="text-4xl font-bold mb-2">FleetForge</h1>
     <p class="mb-4">Built by Jagne Small Business Services – Powering Dispatch & Fleet Growth</p>
-    <a href="dispatch-form.html" class="btn">Get Started</a>
+    <a href="dashboard.html" class="btn">Get Started</a>
   </header>
   <script>
     const link = document.getElementById('loginLink');

--- a/login.html
+++ b/login.html
@@ -37,7 +37,7 @@
           supabase.auth.setSession(JSON.parse(sess).session);
         }
       } else {
-        window.location.href = 'dispatch-form.html';
+        window.location.href = 'dashboard.html';
       }
     });
     const form = document.getElementById('loginForm');
@@ -54,7 +54,7 @@
         document.getElementById('error').textContent = error.message;
       } else {
         localStorage.setItem('sb-session', JSON.stringify(data));
-        window.location.href = 'dispatch-form.html';
+        window.location.href = 'dashboard.html';
       }
     });
   </script>

--- a/pricing.html
+++ b/pricing.html
@@ -32,7 +32,7 @@
     document.getElementById('subscribeBtn').addEventListener('click', () => {
       // Replace URL with your Stripe payment link
       const stripeUrl = 'https://buy.stripe.com/test_placeholder';
-      const successUrl = window.location.origin + '/dispatch-form.html';
+      const successUrl = window.location.origin + '/dashboard.html';
       localStorage.setItem('paid', 'true');
       window.location.href = stripeUrl + '?redirect=' + encodeURIComponent(successUrl);
     });

--- a/signup.html
+++ b/signup.html
@@ -37,7 +37,7 @@
           supabase.auth.setSession(JSON.parse(sess).session);
         }
       } else {
-        window.location.href = 'dispatch-form.html';
+        window.location.href = 'dashboard.html';
       }
     });
     const form = document.getElementById('signupForm');
@@ -54,7 +54,7 @@
         document.getElementById('error').textContent = error.message;
       } else {
         localStorage.setItem('sb-session', JSON.stringify(data));
-        window.location.href = 'pricing.html';
+        window.location.href = 'dashboard.html';
       }
     });
   </script>


### PR DESCRIPTION
## Summary
- rename `dispatch-form.html` to `dashboard.html`
- update nav links and redirects to use the new dashboard
- redirect login and signup to the dashboard
- adjust requireAuth to send unauthenticated users to login and reroute login/signup requests when already authenticated

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687bb80ac704832c909e337f0bfe11e9