### PR TITLE
Add user scoped tables with RLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,20 +3,59 @@ FleetForge – a lightweight, modular Trucking Management System (TMS) built for
 
 ## Database Schema
 
-Create a `loads` table in Supabase with the following columns:
+All application data is scoped to the authenticated user. Each table
+includes a `user_id` column referencing `auth.users(id)`. The key tables
+are:
+
+### `loads`
 
 - `id` (uuid, primary key)
-- `user_id` (uuid, foreign key to auth.users)
+- `user_id` (uuid, foreign key to `auth.users`)
 - `pickup_location` (text)
 - `delivery_location` (text)
 - `rate` (number)
 - `status` (text)
 - `created_at` (timestamp)
 
-Create a `subscriptions` table with:
+### `dispatches`
 
-- `user_id` (uuid, primary key references auth.users)
+- `id` (uuid, primary key)
+- `user_id` (uuid, foreign key to `auth.users`)
+
+### `drivers`
+
+- `id` (uuid, primary key)
+- `user_id` (uuid, foreign key to `auth.users`)
+
+### `carriers`
+
+- `id` (uuid, primary key)
+- `user_id` (uuid, foreign key to `auth.users`)
+
+### `equipment`
+
+- `id` (uuid, primary key)
+- `user_id` (uuid, foreign key to `auth.users`)
+
+### `rate_confirmations`
+
+- `id` (uuid, primary key)
+- `user_id` (uuid, foreign key to `auth.users`)
+
+### `expenses`
+
+- `id` (uuid, primary key)
+- `user_id` (uuid, foreign key to `auth.users`)
+
+### `subscriptions`
+
+- `user_id` (uuid, primary key references `auth.users`)
 - `active` (boolean)
+
+Row level security (RLS) is enabled on all tables. Policies ensure users
+can only read or modify rows where `user_id` matches their authenticated
+`auth.uid()`. An example SQL script that creates the tables and
+policies is provided in `supabase/schema.sql`.
 
 ## Authentication Setup
 
@@ -26,3 +65,4 @@ Copy `supabase-config.example.js` to `supabase-config.js` and add your Supabase 
 cp supabase-config.example.js supabase-config.js
 # edit supabase-config.js with your credentials
 ```
+

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,101 @@
+-- Schema setup for FleetForge
+-- Adds user scoping and Row Level Security policies
+
+-- Loads table
+create table if not exists public.loads (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references auth.users(id),
+    pickup_location text,
+    delivery_location text,
+    rate numeric,
+    status text,
+    created_at timestamp with time zone default now()
+);
+
+-- Dispatches table
+create table if not exists public.dispatches (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references auth.users(id),
+    created_at timestamp with time zone default now()
+);
+
+-- Drivers table
+create table if not exists public.drivers (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references auth.users(id),
+    created_at timestamp with time zone default now()
+);
+
+-- Carriers table
+create table if not exists public.carriers (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references auth.users(id),
+    created_at timestamp with time zone default now()
+);
+
+-- Equipment table
+create table if not exists public.equipment (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references auth.users(id),
+    created_at timestamp with time zone default now()
+);
+
+-- Rate confirmations table
+create table if not exists public.rate_confirmations (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references auth.users(id),
+    created_at timestamp with time zone default now()
+);
+
+-- Expenses table
+create table if not exists public.expenses (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references auth.users(id),
+    created_at timestamp with time zone default now()
+);
+
+-- Enable Row Level Security
+alter table public.loads enable row level security;
+alter table public.dispatches enable row level security;
+alter table public.drivers enable row level security;
+alter table public.carriers enable row level security;
+alter table public.equipment enable row level security;
+alter table public.rate_confirmations enable row level security;
+alter table public.expenses enable row level security;
+
+-- Policy: users can operate only on their own rows
+create policy if not exists "users_read_write_own_rows" on public.loads
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy if not exists "users_read_write_own_rows" on public.dispatches
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy if not exists "users_read_write_own_rows" on public.drivers
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy if not exists "users_read_write_own_rows" on public.carriers
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy if not exists "users_read_write_own_rows" on public.equipment
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy if not exists "users_read_write_own_rows" on public.rate_confirmations
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy if not exists "users_read_write_own_rows" on public.expenses
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+


### PR DESCRIPTION
## Summary
- define user owned tables and policies in `supabase/schema.sql`
- document schema updates and RLS setup in README

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687bb809972c832c8d414a4fb984ed29