### PR TITLE
Add webhook server and rely on Supabase for subscription status

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_KEY=your-service-role-key
+STRIPE_SECRET_KEY=your-stripe-secret-key
+STRIPE_WEBHOOK_SECRET=your-stripe-webhook-secret
+PORT=4242

--- a/README.md
+++ b/README.md
@@ -26,3 +26,17 @@ Copy `supabase-config.example.js` to `supabase-config.js` and add your Supabase 
 cp supabase-config.example.js supabase-config.js
 # edit supabase-config.js with your credentials
 ```
+
+## Webhook Server
+
+A simple Express server handles Stripe webhooks and updates the `subscriptions` table in Supabase. Copy `.env.example` to `.env` and fill in your project keys:
+
+```
+cp .env.example .env
+```
+
+Start the server with:
+
+```
+node server.js
+```

--- a/auth.js
+++ b/auth.js
@@ -31,13 +31,10 @@ async function requirePaid() {
     .eq('user_id', user.id)
     .single();
 
-  const active = !error && data && data.active;
-  if (active) {
-    localStorage.setItem('paid', 'true');
+  if (!error && data && data.active) {
     return true;
   }
 
-  localStorage.removeItem('paid');
   window.location.href = 'pricing.html';
   return false;
 }

--- a/dispatch-form.html
+++ b/dispatch-form.html
@@ -45,7 +45,6 @@
       document.getElementById('logout').addEventListener('click', async (e) => {
         e.preventDefault();
         await supabase.auth.signOut();
-        localStorage.removeItem('paid');
         window.location.href = 'index.html';
       });
       const form = document.getElementById('dispatchForm');

--- a/dispatch-log.html
+++ b/dispatch-log.html
@@ -42,7 +42,6 @@
       document.getElementById('logout').addEventListener('click', async (e) => {
         e.preventDefault();
         await supabase.auth.signOut();
-        localStorage.removeItem('paid');
         window.location.href = 'index.html';
       });
       const tbody = document.querySelector('#logTable tbody');

--- a/index.html
+++ b/index.html
@@ -29,9 +29,8 @@
         link.textContent = 'Logout';
         link.addEventListener('click', async (e) => {
           e.preventDefault();
-          await supabase.auth.signOut();
-          localStorage.removeItem('paid');
-          window.location.reload();
+        await supabase.auth.signOut();
+        window.location.reload();
         });
       }
     });

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "fleetforge",
+  "version": "1.0.0",
+  "description": "FleetForge – a lightweight, modular Trucking Management System (TMS) built for dispatchers and fleet owners.",
+  "main": "auth.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/pricing.html
+++ b/pricing.html
@@ -25,7 +25,6 @@
       document.getElementById('logout').addEventListener('click', async (e) => {
         e.preventDefault();
         await supabase.auth.signOut();
-        localStorage.removeItem('paid');
         window.location.href = 'index.html';
       });
     });
@@ -33,7 +32,6 @@
       // Replace URL with your Stripe payment link
       const stripeUrl = 'https://buy.stripe.com/test_placeholder';
       const successUrl = window.location.origin + '/dispatch-form.html';
-      localStorage.setItem('paid', 'true');
       window.location.href = stripeUrl + '?redirect=' + encodeURIComponent(successUrl);
     });
   </script>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,44 @@
+const express = require('express');
+const Stripe = require('stripe');
+const { createClient } = require('@supabase/supabase-js');
+require('dotenv').config();
+
+const stripe = Stripe(process.env.STRIPE_SECRET_KEY);
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+
+const app = express();
+app.post('/webhook', express.raw({ type: 'application/json' }), async (req, res) => {
+  const sig = req.headers['stripe-signature'];
+  let event;
+  try {
+    event = stripe.webhooks.constructEvent(req.body, sig, process.env.STRIPE_WEBHOOK_SECRET);
+  } catch (err) {
+    console.error('Webhook signature verification failed.', err.message);
+    return res.status(400).send(`Webhook Error: ${err.message}`);
+  }
+
+  try {
+    if (event.type === 'checkout.session.completed') {
+      const session = event.data.object;
+      const userId = session.metadata && session.metadata.user_id;
+      if (userId) {
+        await supabase.from('subscriptions').upsert({ user_id: userId, active: true });
+      }
+    }
+    if (event.type === 'customer.subscription.deleted') {
+      const subscription = event.data.object;
+      const userId = subscription.metadata && subscription.metadata.user_id;
+      if (userId) {
+        await supabase.from('subscriptions').update({ active: false }).eq('user_id', userId);
+      }
+    }
+  } catch (err) {
+    console.error('Error handling event', err);
+    return res.status(500).send('Server error');
+  }
+
+  res.json({ received: true });
+});
+
+const PORT = process.env.PORT || 4242;
+app.listen(PORT, () => console.log(`Webhook server running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- add Express webhook server to update Supabase subscriptions
- document webhook server usage in README
- store Stripe and Supabase credentials in `.env.example`
- update `requirePaid` to only check Supabase
- remove `localStorage` subscription toggle from client pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687bb808bd04832cad51096b8be3484d