### PR TITLE
Improve login state handling using Supabase sessions

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,16 +1,6 @@
 function requireAuth() {
   return supabase.auth.getUser().then(({ data }) => {
     if (!data || !data.user) {
-      const sess = localStorage.getItem('sb-session');
-      if (sess) {
-        return supabase.auth.setSession(JSON.parse(sess).session).then(() => {
-          return supabase.auth.getUser().then(({ data }) => {
-            if (data && data.user) return data.user;
-            window.location.href = 'login.html';
-            return Promise.reject();
-          });
-        });
-      }
       window.location.href = 'login.html';
       return Promise.reject();
     }
@@ -33,11 +23,9 @@ async function requirePaid() {
 
   const active = !error && data && data.active;
   if (active) {
-    localStorage.setItem('paid', 'true');
     return true;
   }
 
-  localStorage.removeItem('paid');
   window.location.href = 'pricing.html';
   return false;
 }

--- a/login.html
+++ b/login.html
@@ -31,12 +31,12 @@
   </main>
   <script>
     supabase.auth.getUser().then(({ data }) => {
-      if (!data || !data.user) {
-        const sess = localStorage.getItem('sb-session');
-        if (sess) {
-          supabase.auth.setSession(JSON.parse(sess).session);
-        }
-      } else {
+      if (data && data.user) {
+        window.location.href = 'dispatch-form.html';
+      }
+    });
+    supabase.auth.onAuthStateChange((event) => {
+      if (event === 'SIGNED_IN') {
         window.location.href = 'dispatch-form.html';
       }
     });
@@ -45,16 +45,13 @@
     form.addEventListener('submit', async (e) => {
       e.preventDefault();
       loading.classList.remove('hidden');
-      const { data, error } = await supabase.auth.signIn({
+      const { error } = await supabase.auth.signIn({
         email: document.getElementById('email').value,
         password: document.getElementById('password').value
       });
       loading.classList.add('hidden');
       if (error) {
         document.getElementById('error').textContent = error.message;
-      } else {
-        localStorage.setItem('sb-session', JSON.stringify(data));
-        window.location.href = 'dispatch-form.html';
       }
     });
   </script>

--- a/signup.html
+++ b/signup.html
@@ -31,13 +31,13 @@
   </main>
   <script>
     supabase.auth.getUser().then(({ data }) => {
-      if (!data || !data.user) {
-        const sess = localStorage.getItem('sb-session');
-        if (sess) {
-          supabase.auth.setSession(JSON.parse(sess).session);
-        }
-      } else {
+      if (data && data.user) {
         window.location.href = 'dispatch-form.html';
+      }
+    });
+    supabase.auth.onAuthStateChange((event) => {
+      if (event === 'SIGNED_IN') {
+        window.location.href = 'pricing.html';
       }
     });
     const form = document.getElementById('signupForm');
@@ -45,16 +45,13 @@
     form.addEventListener('submit', async (e) => {
       e.preventDefault();
       loading.classList.remove('hidden');
-      const { data, error } = await supabase.auth.signUp({
+      const { error } = await supabase.auth.signUp({
         email: document.getElementById('email').value,
         password: document.getElementById('password').value
       });
       loading.classList.add('hidden');
       if (error) {
         document.getElementById('error').textContent = error.message;
-      } else {
-        localStorage.setItem('sb-session', JSON.stringify(data));
-        window.location.href = 'pricing.html';
       }
     });
   </script>


### PR DESCRIPTION
## Summary
- clean up `requireAuth` and `requirePaid` helper logic
- simplify login redirect logic in **login.html** and **signup.html**
- rely on `supabase.auth.onAuthStateChange` and `supabase.auth.getUser` for session management

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687bb807d9b8832cb4013a3523cec5b8