### PR TITLE
Remove deprecated sb-session logic

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -4,23 +4,9 @@ function requireAuth() {
     const isAuthPage = /(login|signup)(\.html)?$/.test(path);
 
     if (!data || !data.user) {
-      const sess = localStorage.getItem('sb-session');
-      if (sess) {
-        return supabase.auth.setSession(JSON.parse(sess).session).then(() => {
-          return supabase.auth.getUser().then(({ data }) => {
-            if (data && data.user) {
-              if (isAuthPage) {
-                window.location.href = 'dashboard.html';
-                return Promise.reject();
-              }
-              return data.user;
-            }
-            window.location.href = 'login.html';
-            return Promise.reject();
-          });
-        });
+      if (!isAuthPage) {
+        window.location.href = 'login.html';
       }
-      window.location.href = 'login.html';
       return Promise.reject();
     }
 

--- a/login.html
+++ b/login.html
@@ -31,12 +31,7 @@
   </main>
   <script>
     supabase.auth.getUser().then(({ data }) => {
-      if (!data || !data.user) {
-        const sess = localStorage.getItem('sb-session');
-        if (sess) {
-          supabase.auth.setSession(JSON.parse(sess).session);
-        }
-      } else {
+      if (data && data.user) {
         window.location.href = 'dashboard.html';
       }
     });
@@ -53,7 +48,6 @@
       if (error) {
         document.getElementById('error').textContent = error.message;
       } else {
-        localStorage.setItem('sb-session', JSON.stringify(data));
         window.location.href = 'dashboard.html';
       }
     });

--- a/signup.html
+++ b/signup.html
@@ -31,12 +31,7 @@
   </main>
   <script>
     supabase.auth.getUser().then(({ data }) => {
-      if (!data || !data.user) {
-        const sess = localStorage.getItem('sb-session');
-        if (sess) {
-          supabase.auth.setSession(JSON.parse(sess).session);
-        }
-      } else {
+      if (data && data.user) {
         window.location.href = 'dashboard.html';
       }
     });
@@ -53,7 +48,6 @@
       if (error) {
         document.getElementById('error').textContent = error.message;
       } else {
-        localStorage.setItem('sb-session', JSON.stringify(data));
         window.location.href = 'dashboard.html';
       }
     });


### PR DESCRIPTION
## Summary
- remove sb-session localStorage references
- simplify `requireAuth()` to rely on Supabase session
- update login and signup pages to redirect based on Supabase state

## Testing
- `grep -nR sb-session -n`


------
https://chatgpt.com/codex/tasks/task_e_687c851a0314832c86583ebfa145c5e4