### PR TITLE
Fix log rendering with safer DOM operations

### DIFF
--- a/dispatch-log.html
+++ b/dispatch-log.html
@@ -57,13 +57,18 @@
       loading.classList.add('hidden');
       (data || []).forEach(d => {
         const row = document.createElement('tr');
-        row.innerHTML = `
-          <td class="px-2 py-1">${d.pickup_location}</td>
-          <td class="px-2 py-1">${d.delivery_location}</td>
-          <td class="px-2 py-1">${d.rate}</td>
-          <td class="px-2 py-1">${d.status}</td>
-          <td class="px-2 py-1">${new Date(d.created_at).toLocaleString()}</td>
-        `;
+        [
+          d.pickup_location,
+          d.delivery_location,
+          d.rate,
+          d.status,
+          new Date(d.created_at).toLocaleString()
+        ].forEach(text => {
+          const cell = document.createElement('td');
+          cell.className = 'px-2 py-1';
+          cell.textContent = text;
+          row.appendChild(cell);
+        });
         tbody.appendChild(row);
       });
     });


### PR DESCRIPTION
## Summary
- avoid HTML concatenation when rendering dispatch rows

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_687c851d4a84832c9ea5926aa3fcbf69