### PR TITLE
Add Playwright E2E test for signup flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,24 @@ Then visit the printed URL (usually `http://localhost:3000`).
 
 ## Testing
 
-1. Copy and configure `supabase-config.js`.
+Automated tests use [Playwright](https://playwright.dev). Configure Supabase
+and install dependencies before running them.
+
+1. Copy `supabase-config.example.js` to `supabase-config.js` and add your
+   Supabase credentials.
 2. Create the tables and policies as shown above.
-3. Start the static server and sign up for an account.
-4. Add a load via `dashboard.html` and verify it appears in the log for that
-   user only.
+3. Install dependencies and Playwright browsers:
+
+   ```bash
+   npm install
+   npx playwright install
+   ```
+
+4. Run the tests:
+
+   ```bash
+   npm test
+   ```
+
+The test suite starts a local server, signs up a user, registers a company, and
+verifies that the user can log out and log back in without re-registering.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "fleetforge",
+  "version": "1.0.0",
+  "description": "FleetForge – a lightweight, modular Trucking Management System (TMS) built for dispatchers and fleet owners.",
+  "main": "auth.js",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "devDependencies": {
+    "@playwright/test": "^1.41.2"
+  }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  retries: 0,
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+  },
+  webServer: {
+    command: 'npx serve -s . -l 3000',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+  }
+});

--- a/tests/flow.spec.js
+++ b/tests/flow.spec.js
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+
+const timestamp = Date.now();
+const email = `test+${timestamp}@example.com`;
+const password = 'TestPass123!';
+
+test('user signup, company registration, and login', async ({ page }) => {
+  // Sign up a new user
+  await page.goto('/signup.html');
+  await page.fill('#email', email);
+  await page.fill('#password', password);
+  await page.click('button[type="submit"]');
+  await page.waitForURL('**/register-company.html');
+  await expect(page).toHaveURL(/register-company\.html/);
+
+  // Register company
+  await page.fill('#name', 'Test Company');
+  await page.fill('#address', '123 Testing Way');
+  await page.click('button[type="submit"]');
+  await page.waitForURL('**/dashboard.html');
+  await expect(page).toHaveURL(/dashboard\.html/);
+  await expect(page.locator('text=Dashboard')).toBeVisible();
+
+  // Log out
+  await page.click('#logout');
+  await page.waitForURL('**/index.html');
+
+  // Log back in
+  await page.goto('/login.html');
+  await page.fill('#email', email);
+  await page.fill('#password', password);
+  await page.click('button[type="submit"]');
+  await page.waitForURL('**/dashboard.html');
+  await expect(page).toHaveURL(/dashboard\.html/);
+  await expect(page.locator('text=Dashboard')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add Playwright configuration and test for signup and login flow
- document automated testing steps in README

## Testing
- `npm test` *(fails: `playwright: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687e7455e0bc832ca07f5da14fb343f0