### PR TITLE
Insert user record after signup

### DIFF
--- a/signup.html
+++ b/signup.html
@@ -55,6 +55,10 @@
         document.getElementById('error').textContent = error.message;
       } else {
         const { data: { user } } = await client.auth.getUser();
+        const { error: insertError } = await client
+          .from('users')
+          .insert({ user_id: user.id, email: user.email });
+        if (insertError) console.error(insertError);
         const company = await getCompany(user.id);
         if (company) {
           window.currentCompany = company;


### PR DESCRIPTION
## Summary
- save new user into the `users` table on signup and log any error

## Testing
- `npm test` *(fails: playwright not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687ecf41104c832c95737203c8363895