### PR TITLE
Add extended company registration fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ Create a `companies` table with:
 
 - `id` (uuid, primary key)
 - `user_id` (uuid, foreign key to auth.users)
-- `name` (text)
+- `company_name` (text)
+- `company_email` (text)
+- `phone_number` (text)
+- `address` (text)
+- `company_logo` (text)
 
 Create a `users` table with:
 

--- a/register-company.html
+++ b/register-company.html
@@ -17,10 +17,19 @@
   <main class="max-w-md mx-auto p-4">
     <form id="companyForm" class="space-y-4">
       <label class="block">Company Name
-        <input type="text" id="name" class="border p-2 w-full" required />
+        <input type="text" id="company_name" class="border p-2 w-full" required />
+      </label>
+      <label class="block">Company Email
+        <input type="email" id="company_email" class="border p-2 w-full" required />
+      </label>
+      <label class="block">Phone Number
+        <input type="tel" id="phone_number" class="border p-2 w-full" required />
       </label>
       <label class="block">Address
         <input type="text" id="address" class="border p-2 w-full" required />
+      </label>
+      <label class="block">Company Logo URL
+        <input type="url" id="company_logo" class="border p-2 w-full" required />
       </label>
       <button type="submit" class="btn">Save Company</button>
     </form>
@@ -30,25 +39,34 @@
   <script>
     requireAuth().then(async (user) => {
       const existing = await getCompany(user.id);
-      if (existing) {
-        window.currentCompany = existing;
-        window.location.href = 'dashboard.html';
-        return;
-      }
       const form = document.getElementById('companyForm');
       const loading = document.getElementById('loading');
       const errorEl = document.getElementById('error');
+
+      if (existing) {
+        form.company_name.value = existing.company_name || '';
+        form.company_email.value = existing.company_email || '';
+        form.phone_number.value = existing.phone_number || '';
+        form.address.value = existing.address || '';
+        form.company_logo.value = existing.company_logo || '';
+      }
+
       form.addEventListener('submit', async (e) => {
         e.preventDefault();
         loading.classList.remove('hidden');
-        const { data, error } = await client
-          .from('companies')
-          .insert({
-            user_id: user.id,
-            name: document.getElementById('name').value,
-            address: document.getElementById('address').value
-          })
-          .single();
+        const payload = {
+          user_id: user.id,
+          company_name: form.company_name.value,
+          company_email: form.company_email.value,
+          phone_number: form.phone_number.value,
+          address: form.address.value,
+          company_logo: form.company_logo.value
+        };
+
+        const { data, error } = existing
+          ? await client.from('companies').update(payload).eq('user_id', user.id).single()
+          : await client.from('companies').insert(payload).single();
+
         loading.classList.add('hidden');
         if (error) {
           console.error(error);

--- a/tests/flow.spec.js
+++ b/tests/flow.spec.js
@@ -14,8 +14,11 @@ test('user signup, company registration, and login', async ({ page }) => {
   await expect(page).toHaveURL(/register-company\.html/);
 
   // Register company
-  await page.fill('#name', 'Test Company');
+  await page.fill('#company_name', 'Test Company');
+  await page.fill('#company_email', 'test-company@example.com');
+  await page.fill('#phone_number', '123-456-7890');
   await page.fill('#address', '123 Testing Way');
+  await page.fill('#company_logo', 'https://example.com/logo.png');
   await page.click('button[type="submit"]');
   await page.waitForURL('**/dashboard.html');
   await expect(page).toHaveURL(/dashboard\.html/);


### PR DESCRIPTION
## Summary
- expand database schema documentation for new company details
- add company email, phone, logo fields in register-company form
- prefill company info when available and update on submit
- adjust e2e flow for updated registration

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f203847cc832c867ddc07afc3cdfe