### PR TITLE
Implement local auth helper

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -10,11 +10,24 @@ function storeCompany(company) {
 function clearCompany() {
   localStorage.removeItem('ff_company_id');
   localStorage.removeItem('ff_company_name');
+  localStorage.removeItem('ff_user_id');
 }
 
 async function getCurrentUser() {
   const { data } = await client.auth.getUser();
   return data ? data.user : null;
+}
+
+// Local auth check based on saved user id
+function requireLocalAuth() {
+  const userId = localStorage.getItem('ff_user_id');
+  if (!userId) {
+    window.location.href = 'login.html';
+    return null;
+  }
+  const nav = document.querySelector('nav');
+  if (nav) nav.classList.remove('hidden');
+  return userId;
 }
 
 async function requireAuth() {

--- a/dashboard.html
+++ b/dashboard.html
@@ -43,6 +43,7 @@
     </form>
   </main>
   <script>
+    requireLocalAuth();
     requireAuth().then(async ({ user }) => {
       const company = await requireCompany();
       if (!company || !await requirePaid()) return;

--- a/dispatch-log.html
+++ b/dispatch-log.html
@@ -40,6 +40,7 @@
     <p id="loading" class="text-blue-600 hidden">Loading...</p>
   </main>
   <script>
+    requireLocalAuth();
     requireAuth().then(async ({ user }) => {
       const company = await requireCompany();
       if (!company || !await requirePaid()) return;

--- a/drivers.html
+++ b/drivers.html
@@ -40,6 +40,7 @@
     </form>
   </main>
   <script>
+    requireLocalAuth();
     requireAuth().then(async ({ user }) => {
       const company = await requireCompany();
       if (!company || !await requirePaid()) return;

--- a/equipment.html
+++ b/equipment.html
@@ -40,6 +40,7 @@
     </form>
   </main>
   <script>
+    requireLocalAuth();
     requireAuth().then(async ({ user }) => {
       const company = await requireCompany();
       if (!company || !await requirePaid()) return;

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
     <a href="#" onclick="navigate('dashboard.html'); return false;" class="btn">Get Started</a>
   </header>
   <script>
+    requireLocalAuth();
     requireAuth();
   </script>
   <footer class="text-center text-sm text-gray-600 p-4">

--- a/login.html
+++ b/login.html
@@ -33,6 +33,7 @@
     client.auth.getSession().then(async ({ data }) => {
       if (data && data.session) {
         const user = data.session.user;
+        localStorage.setItem('ff_user_id', user.id);
         const company = await getCompanyForUser(user.id);
         if (company) {
           storeCompany(company);
@@ -57,6 +58,7 @@
         document.getElementById('error').textContent = error.message;
       } else {
         const { data: { user } } = await client.auth.getUser();
+        localStorage.setItem('ff_user_id', user.id);
         const company = await getCompanyForUser(user.id);
         if (company) {
           storeCompany(company);

--- a/pricing.html
+++ b/pricing.html
@@ -26,6 +26,7 @@
     <button id="subscribeBtn" class="btn">Subscribe with Stripe</button>
   </main>
   <script>
+    requireLocalAuth();
     requireAuth().then(async () => {
       const company = await requireCompany();
       if (!company) return;

--- a/rate-confirmations.html
+++ b/rate-confirmations.html
@@ -40,6 +40,7 @@
     </form>
   </main>
   <script>
+    requireLocalAuth();
     requireAuth().then(async ({ user }) => {
       const company = await requireCompany();
       if (!company || !await requirePaid()) return;

--- a/register-company.html
+++ b/register-company.html
@@ -37,6 +37,7 @@
     <p id="error" class="error"></p>
   </main>
   <script>
+    requireLocalAuth();
     requireAuth().then(async ({ user }) => {
       const existing = await getCompanyForUser(user.id);
       const form = document.getElementById('companyForm');

--- a/signup.html
+++ b/signup.html
@@ -33,6 +33,7 @@
     client.auth.getSession().then(async ({ data }) => {
       if (data && data.session) {
         const user = data.session.user;
+        localStorage.setItem('ff_user_id', user.id);
         const company = await getCompanyForUser(user.id);
         if (company) {
           storeCompany(company);
@@ -57,6 +58,7 @@
         document.getElementById('error').textContent = error.message;
       } else {
         const { data: { user } } = await client.auth.getUser();
+        localStorage.setItem('ff_user_id', user.id);
         const { error: insertError } = await client
           .from('users')
           .insert({ user_id: user.id, email: user.email });


### PR DESCRIPTION
## Summary
- add `requireLocalAuth` helper
- clear `ff_user_id` on logout
- persist `ff_user_id` after login/signup
- use `requireLocalAuth` across protected pages

## Testing
- `npm test` *(fails: playwright missing)*

------
https://chatgpt.com/codex/tasks/task_e_687fe4518c08832c9e909e9bd76ef1e5