### PR TITLE
Update logo upload to use Supabase storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Create a `companies` table with:
 - `company_email` (text)
 - `phone_number` (text)
 - `address` (text)
-- `company_logo` (text)
+- `logo_url` (text)
 
 Create a `users` table with:
 

--- a/register-company.html
+++ b/register-company.html
@@ -28,9 +28,10 @@
       <label class="block">Address
         <input type="text" id="address" class="border p-2 w-full" required />
       </label>
-      <label class="block">Company Logo URL
-        <input type="url" id="company_logo" class="border p-2 w-full" required />
+      <label class="block">Company Logo
+        <input type="file" id="logo" accept="image/*" class="border p-2 w-full" />
       </label>
+      <p id="logoStatus" class="text-sm"></p>
       <button type="submit" class="btn">Save Company</button>
     </form>
     <p id="loading" class="text-blue-600 hidden">Saving...</p>
@@ -43,25 +44,47 @@
       const form = document.getElementById('companyForm');
       const loading = document.getElementById('loading');
       const errorEl = document.getElementById('error');
+      const logoStatus = document.getElementById('logoStatus');
 
       if (existing) {
         form.company_name.value = existing.company_name || '';
         form.company_email.value = existing.company_email || '';
         form.phone_number.value = existing.phone_number || '';
         form.address.value = existing.address || '';
-        form.company_logo.value = existing.company_logo || '';
       }
 
       form.addEventListener('submit', async (e) => {
         e.preventDefault();
         loading.classList.remove('hidden');
+        errorEl.textContent = '';
+        logoStatus.textContent = '';
+
+        let logoUrl = null;
+        if (form.logo.files.length > 0) {
+          const file = form.logo.files[0];
+          const filePath = `${user.id}/${Date.now()}_${file.name}`;
+          const { error: uploadError } = await client.storage
+            .from('company-logos')
+            .upload(filePath, file);
+          if (uploadError) {
+            loading.classList.add('hidden');
+            errorEl.textContent = uploadError.message;
+            return;
+          }
+          const { data: publicData } = client.storage
+            .from('company-logos')
+            .getPublicUrl(filePath);
+          logoUrl = publicData.publicUrl;
+          logoStatus.textContent = 'Logo uploaded successfully.';
+        }
+
         const payload = {
           user_id: user.id,
           company_name: form.company_name.value,
           company_email: form.company_email.value,
           phone_number: form.phone_number.value,
           address: form.address.value,
-          company_logo: form.company_logo.value
+          logo_url: logoUrl
         };
 
         const { data, error } = existing

--- a/tests/flow.spec.js
+++ b/tests/flow.spec.js
@@ -1,4 +1,8 @@
 import { test, expect } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const timestamp = Date.now();
 const email = `test+${timestamp}@example.com`;
@@ -18,7 +22,8 @@ test('user signup, company registration, and login', async ({ page }) => {
   await page.fill('#company_email', 'test-company@example.com');
   await page.fill('#phone_number', '123-456-7890');
   await page.fill('#address', '123 Testing Way');
-  await page.fill('#company_logo', 'https://example.com/logo.png');
+  const logoPath = path.join(__dirname, '../jsbs-logo.jpg');
+  await page.setInputFiles('#logo', logoPath);
   await page.click('button[type="submit"]');
   await page.waitForURL('**/dashboard.html');
   await expect(page).toHaveURL(/dashboard\.html/);


### PR DESCRIPTION
## Summary
- make company logo optional with file upload
- store uploaded image URL in `logo_url`
- adjust company schema docs
- update Playwright test for file upload

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_687feee13724832cb2898dcc5ea2026b