### PR TITLE
Add logo column migration and frontend check

### DIFF
--- a/register-company.html
+++ b/register-company.html
@@ -38,6 +38,16 @@
     <p id="error" class="error"></p>
   </main>
   <script>
+    async function ensureLogoUrlColumn() {
+      const { error } = await client.from('companies').select('logo_url').limit(1);
+      if (error && /logo_url/.test(error.message)) {
+        const { error: rpcError } = await client.rpc('add_logo_url_column');
+        if (rpcError) throw rpcError;
+      } else if (error) {
+        throw error;
+      }
+    }
+
     requireLocalAuth();
     requireAuth().then(async ({ user }) => {
       const existing = await getCompanyForUser(user.id);
@@ -58,6 +68,13 @@
         loading.classList.remove('hidden');
         errorEl.textContent = '';
         logoStatus.textContent = '';
+        try {
+          await ensureLogoUrlColumn();
+        } catch (err) {
+          loading.classList.add('hidden');
+          errorEl.textContent = err.message;
+          return;
+        }
 
         let logoUrl = null;
         if (form.logo.files.length > 0) {

--- a/sql/add_logo_url_column.sql
+++ b/sql/add_logo_url_column.sql
@@ -1,0 +1,16 @@
+-- Adds logo_url column to companies table if it doesn't exist
+create or replace function add_logo_url_column()
+returns void
+language plpgsql
+as $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'companies'
+      and column_name = 'logo_url'
+  ) then
+    alter table public.companies add column logo_url text;
+  end if;
+end;
+$$;


### PR DESCRIPTION
## Summary
- add SQL function `add_logo_url_column` to create `companies.logo_url` if missing
- update Register Company flow with `ensureLogoUrlColumn` to run the RPC when needed

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e3a87ecc832c92a1ef89a374d6c5