### PR TITLE
Use env vars for Supabase config

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,23 @@ Create a `rate_confirmations` table with:
 
 ## Authentication Setup
 
-Copy `supabase-config.example.js` to `supabase-config.js` and add your Supabase project URL and anon key. These values are required for login and database access.
+Create a `supabase-config.js` file that loads your Supabase credentials from the environment. You can start from `supabase-config.example.js`:
 
 ```
 cp supabase-config.example.js supabase-config.js
-# edit supabase-config.js with your credentials
 ```
+
+Edit `supabase-config.js` so it contains:
+
+```javascript
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;
+
+// Initialize Supabase client (compatible with supabase-js v2)
+const client = supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+```
+
+Set the `SUPABASE_URL` and `SUPABASE_ANON_KEY` environment variables before serving the site or running tests.
 
 ## Row Level Security
 
@@ -137,8 +148,10 @@ Then visit the printed URL (usually `http://localhost:3000`).
 Automated tests use [Playwright](https://playwright.dev). Configure Supabase
 and install dependencies before running them.
 
-1. Copy `supabase-config.example.js` to `supabase-config.js` and add your
-   Supabase credentials.
+1. Copy `supabase-config.example.js` to `supabase-config.js` and replace the
+   credential values with `process.env.SUPABASE_URL` and
+   `process.env.SUPABASE_ANON_KEY` so the tests can read them from your
+   environment.
 2. Create the tables and policies as shown above.
 3. Install dependencies and Playwright browsers:
 

--- a/supabase-config.js
+++ b/supabase-config.js
@@ -1,6 +1,6 @@
-// Replace with your Supabase project credentials
-const SUPABASE_URL = 'https://qszdzpuzvdbioqtrigqo.supabase.co';
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFzemR6cHV6dmRiaW9xdHJpZ3FvIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTI3ODk0NDYsImV4cCI6MjA2ODM2NTQ0Nn0.N52yVljc8rwQ4k0rNAej1AbfBoH0hickKpsIQjQz9Og';
+// Read Supabase project credentials from environment variables
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;
 
 // Initialize Supabase client (compatible with supabase-js v2)
 const client = supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);


### PR DESCRIPTION
## Summary
- load Supabase URL and anon key from environment in `supabase-config.js`
- explain in README how to generate the local config using environment variables

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e3a9631c832c9d6cc5020b10055b