### PR TITLE
Return full company details

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -42,11 +42,19 @@ async function requireAuth() {
 async function getCompanyForUser(userId) {
   const { data, error } = await client
     .from('companies')
-    .select('id, company_name, name')
+    .select('id, company_name, name, company_email, phone_number, address, logo_url')
     .eq('user_id', userId)
     .single();
   if (error) return null;
-  return { id: data.id, name: data.company_name || data.name };
+  return {
+    id: data.id,
+    name: data.company_name || data.name,
+    company_name: data.company_name,
+    company_email: data.company_email,
+    phone_number: data.phone_number,
+    address: data.address,
+    logo_url: data.logo_url
+  };
 }
 
 async function loadCompany() {


### PR DESCRIPTION
## Summary
- expose `company_email`, `phone_number`, `address` and `logo_url` in `getCompanyForUser`
- return these fields so editing a company prepopulates all inputs

## Testing
- `npm test` *(fails: `playwright` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688100d97198832cbb81c7ed7a17ed0f